### PR TITLE
fix: Add XXE protection and XmlSerializer cache

### DIFF
--- a/Paywire.NET/PaywireClient.cs
+++ b/Paywire.NET/PaywireClient.cs
@@ -1,9 +1,11 @@
 ﻿using Paywire.NET.Models.Base;
 using RestSharp;
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Serialization;
 using Paywire.NET.Models.BatchInquiry;
 using Paywire.NET.Models.BinValidation;
@@ -30,6 +32,7 @@ namespace Paywire.NET
         private readonly PaywireClientOptions _paywireClientOptions;
         private readonly RestClient _restClient;
         private readonly TimeSpan _defaultTimeout = TimeSpan.FromSeconds(30);
+        private static readonly ConcurrentDictionary<Type, XmlSerializer> _serializerCache = new();
 
         public PaywireClient(PaywireClientOptions options)
         {
@@ -123,13 +126,7 @@ namespace Paywire.NET
                 }
 
                 // Setup XML deserialization
-                var emptyNamespace = new XmlSerializerNamespaces();
-                emptyNamespace.Add("", "");
-                
-                var xmlSerializer = new XmlSerializer(
-                    typeof(T), 
-                    new XmlRootAttribute("PAYMENTRESPONSE") { Namespace = "" }
-                );
+                var xmlSerializer = _serializerCache.GetOrAdd(typeof(T), t => new XmlSerializer(t, new XmlRootAttribute("PAYMENTRESPONSE") { Namespace = "" }));
 
                 // Handle response content
                 if (!string.IsNullOrEmpty(response.Content))
@@ -137,7 +134,13 @@ namespace Paywire.NET
                     try
                     {
                         using TextReader textReader = new StringReader(response.Content);
-                        var deserializedResponse = (T)xmlSerializer.Deserialize(textReader);
+                        var xmlSettings = new XmlReaderSettings
+                        {
+                            DtdProcessing = DtdProcessing.Prohibit,
+                            XmlResolver = null
+                        };
+                        using var xmlReader = XmlReader.Create(textReader, xmlSettings);
+                        var deserializedResponse = (T)xmlSerializer.Deserialize(xmlReader);
                         
                         if (deserializedResponse != null)
                         {


### PR DESCRIPTION
## Summary
- **XXE Prevention**: Wrap XML deserialization in `XmlReader` with `DtdProcessing.Prohibit` and `XmlResolver = null` to prevent XML External Entity (XXE) injection attacks
- **Memory Leak Fix**: Cache `XmlSerializer` instances in a static `ConcurrentDictionary` to prevent assembly leak caused by repeated `new XmlSerializer(type, XmlRootAttribute)` calls — each uncached call generates a dynamic assembly that cannot be garbage collected
- **Cleanup**: Remove unused `XmlSerializerNamespaces` variable

## Details
The `XmlSerializer` constructor overload that accepts an `XmlRootAttribute` does not use the framework's built-in caching, meaning every call to `SendRequest<T>()` was creating a new serializer assembly that leaked memory. The `ConcurrentDictionary` cache ensures each type's serializer is created only once and reused across all subsequent requests.

The XXE protection follows OWASP best practices by explicitly prohibiting DTD processing, which prevents attackers from injecting malicious XML that could read local files or perform server-side request forgery (SSRF).

## Test plan
- [x] Solution builds with 0 errors (`dotnet build --configuration Release`)
- [ ] Existing integration tests pass (requires Paywire staging credentials)
- [ ] Verify deserialization still works correctly for all response types