### PR TITLE
fix: Correct data types and remove duplicates in response models

### DIFF
--- a/Paywire.NET/Models/Base/BasePaywireResponse.cs
+++ b/Paywire.NET/Models/Base/BasePaywireResponse.cs
@@ -25,7 +25,7 @@ public class BasePaywireResponse
 
             return RAW_RESULT.ToUpper() == "APPROVED" ? PaywireResult.Approval : PaywireResult.Unknown;
         }
-        set => throw new NotImplementedException();
+        set { }
     }
 
     /// <summary>
@@ -57,4 +57,6 @@ public class BasePaywireResponse
     /// Custom third-party id to be associated with this transaction.
     /// </summary>
     public string PWCUSTOMID1 {get; set; }
+
+    public string PWCUSTOMID2 { get; set; }
 }

--- a/Paywire.NET/Models/Base/Customer.cs
+++ b/Paywire.NET/Models/Base/Customer.cs
@@ -99,7 +99,7 @@ public class Customer
     /// <summary>
     /// Overrides the configured Sales Tax rate.	
     /// </summary>
-    public double ADJTAXRATE { get; set; }
+    public double? ADJTAXRATE { get; set; }
     /// <summary>
     /// Transaction custom description message.	
     /// </summary>

--- a/Paywire.NET/Models/Base/PaywireResult.cs
+++ b/Paywire.NET/Models/Base/PaywireResult.cs
@@ -25,5 +25,7 @@ public enum PaywireResult
     [XmlEnum("PENDING")]
     Pending,
     [XmlEnum("SUCCESS")]
-    Success
+    Success,
+    [XmlEnum("COMPLETED")]
+    Completed
 }

--- a/Paywire.NET/Models/GetConsumerFee/GetConsumerFeeRequest.cs
+++ b/Paywire.NET/Models/GetConsumerFee/GetConsumerFeeRequest.cs
@@ -14,8 +14,6 @@ namespace Paywire.NET.Models.GetConsumerFee
 
     public class GetConsumerFeeRequest : BasePaywireRequest
     {
-        public string PWINVOICENUMBER { get; set; }
-
         //Customer Object
         [XmlElement("CUSTOMER")] public Customer CUSTOMER { get; set; } // Put the shit below into this... 
 

--- a/Paywire.NET/Models/GetConsumerFee/GetConsumerFeeResponse.cs
+++ b/Paywire.NET/Models/GetConsumerFee/GetConsumerFeeResponse.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.AccessControl;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 using Paywire.NET.Models.Base;
 
 namespace Paywire.NET.Models.GetConsumerFee

--- a/Paywire.NET/Models/PreAuth/PreAuthResponse.cs
+++ b/Paywire.NET/Models/PreAuth/PreAuthResponse.cs
@@ -70,7 +70,7 @@ namespace Paywire.NET.Models.PreAuth
         /// <summary>
         /// Indicate if the card is a debit or credit card.
         /// </summary>
-        public bool ISDEBIT { get; set; }
+        public string ISDEBIT { get; set; }
         /// <summary>
         /// Periodic plan ID.
         /// </summary>

--- a/Paywire.NET/Models/Sale/SaleResponse.cs
+++ b/Paywire.NET/Models/Sale/SaleResponse.cs
@@ -84,7 +84,7 @@ public class SaleResponse : BasePaywireResponse
     /// <summary>
     /// Indicate if the card is a debit or credit card.
     /// </summary>
-    public bool ISDEBIT { get; set; }
+    public string ISDEBIT { get; set; }
     /// <summary>
     /// Processor decline code.
     /// </summary>

--- a/Paywire.NET/Models/StoreToken/StoreTokenResponse.cs
+++ b/Paywire.NET/Models/StoreToken/StoreTokenResponse.cs
@@ -51,10 +51,6 @@ namespace Paywire.NET.Models.StoreToken
         /// </summary>
         /// <see cref="https://project.paywire.com/dbtranz/docs/OSBP/files/Development.html?csharp#avs-codes"/>
         public string AVSCODE { get; set; }
-        /// <summary>
-        /// Paywire Customer Identifier. Will be returned if ADDCUSTOMER is set to TRUE in the request.
-        /// </summary>
-        public string PWCID { get; set; }
 
     }
 }

--- a/Paywire.NET/Models/TokenSale/TokenSaleResponse.cs
+++ b/Paywire.NET/Models/TokenSale/TokenSaleResponse.cs
@@ -67,7 +67,5 @@ namespace Paywire.NET.Models.TokenSale
         /// Transaction CVV result: 1 for a match, 0 for a failure.
         /// </summary>
         public string CVVCODE { get; set; }
-
-        public string PWCUSTOMID2 { get; set; }
     }
 }

--- a/Paywire.NET/Models/Verification/VerificationResponse.cs
+++ b/Paywire.NET/Models/Verification/VerificationResponse.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 using Paywire.NET.Models.Base;
 
 namespace Paywire.NET.Models.Verification
@@ -14,7 +9,7 @@ namespace Paywire.NET.Models.Verification
         /// <summary>
         /// Batch number
         /// </summary>
-        public int BATCHID { get; set; }
+        public string BATCHID { get; set; }
 
         /// <summary>
         /// Authorization code associated with the transaction
@@ -45,7 +40,7 @@ namespace Paywire.NET.Models.Verification
         /// <summary>
         /// Payment amount.
         /// </summary>
-        public double AMOUNT { get; set; }
+        public string AMOUNT { get; set; }
 
         /// <summary>
         /// Masked credit card number.
@@ -55,12 +50,7 @@ namespace Paywire.NET.Models.Verification
         /// <summary>
         /// Credit card type.
         /// </summary>
-        public string CCTYPE { get; set; } 
-
-        /// <summary>
-        /// Client custom ID.
-        /// </summary>
-        public string PWCUSTOMID2 { get; set; }
+        public string CCTYPE { get; set; }
 
         /*
          * RESULT	string	China UnionPay transaction result.	


### PR DESCRIPTION
## Summary
- **ISDEBIT** (`SaleResponse`, `PreAuthResponse`): Changed from `bool` to `string` — API returns string values like "Y"/"N", not true/false
- **BATCHID** (`VerificationResponse`): Changed from `int` to `string` — consistent with all other response models
- **AMOUNT** (`VerificationResponse`): Changed from `double` to `string` — consistent with all other response models
- **ADJTAXRATE** (`Customer`): Changed from `double` to `double?` — optional field that causes XML deserialization errors when absent
- **RESULT setter** (`BasePaywireResponse`): Replaced `throw new NotImplementedException()` with no-op — prevents runtime crash during XML deserialization
- **PWCUSTOMID2**: Added to `BasePaywireResponse`; removed duplicates from `VerificationResponse` and `TokenSaleResponse` (CS0108)
- **PWCID**: Removed duplicate from `StoreTokenResponse` (CS0108, inherited from base)
- **PWINVOICENUMBER**: Removed duplicate from `GetConsumerFeeRequest` (inherited from base)
- **Completed**: Added `[XmlEnum("COMPLETED")] Completed` to `PaywireResult` enum
- **Unused imports**: Removed `System.Security.AccessControl` from `GetConsumerFeeResponse` and 5 unused `System.*` imports from `VerificationResponse`

## Test plan
- [x] Solution builds with 0 errors (`dotnet build --configuration Release`)
- [x] No new warnings introduced (CS0108 warnings resolved)
- [ ] Existing integration tests pass (requires Paywire credentials)