### PR TITLE
fix: Harden CI/CD with PR checks, caching, and dependabot fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,14 +3,8 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
-# version: 2
-# updates:
-#  - package-ecosystem: "" # See documentation for possible values
-#     directory: "/" # Location of package manifests
-#     schedule:
-#       interval: "weekly"
 version: 2
-    
+
 updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -19,18 +13,19 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 10
     groups:
-      dotnet:
+      actions:
         patterns:
          - "*" # Prefer a single PR per solution update.
+    reviewers:
+      - "@Spire-Recovery-Solutions/devs"
   # NuGet packages
   - package-ecosystem: "nuget"
-    registries: "*"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 25
     groups:
-      dotnet:
+      nuget-packages:
         patterns:
           - "*"
     reviewers:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,61 @@
+name: PR Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: nuget-
+
+    - name: Restore
+      run: dotnet restore Paywire.NET/Paywire.NET.sln
+
+    - name: Build
+      run: dotnet build Paywire.NET/Paywire.NET.sln --configuration Release --no-restore
+
+    - name: Test
+      run: |
+        cd Paywire.NET.Tests
+        dotnet test --no-restore --logger "trx;LogFileName=test-results.trx" --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~UnitTests"
+
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: Unit Tests
+        path: Paywire.NET.Tests/TestResults/*.trx
+        reporter: dotnet-trx
+
+    - name: Upload coverage
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: coverage-report
+        path: Paywire.NET.Tests/TestResults/**/coverage.cobertura.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,17 +8,31 @@ on:
       - main
       - alpha
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: nuget-
 
     - name: Set Branch-Specific Variables
       id: branch_vars
@@ -38,7 +52,7 @@ jobs:
     - name: Test
       run: |
         cd Paywire.NET.Tests
-        dotnet test
+        dotnet test --no-restore
       env:
         PWCLIENTID: ${{ secrets.PWCLIENTID }}
         PWUSER: ${{ secrets.PWUSER }}
@@ -54,4 +68,4 @@ jobs:
     - name: Push to NuGet
       run: |
         cd Paywire.NET
-        dotnet nuget push nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        dotnet nuget push nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
- Add new `pr-check.yml` workflow for pull request validation with build, test, coverage, and test reporting
- Harden `publish.yml` with `fetch-depth: 0`, job timeout, concurrency control, NuGet caching, and `--skip-duplicate` on push
- Fix `dependabot.yml`: remove invalid `registries: "*"`, add reviewers to github-actions, rename groups for clarity

## Changes
- **`.github/workflows/pr-check.yml`** (new): PR check workflow with concurrency, NuGet cache, unit test filtering, test reporter, and coverage upload
- **`.github/workflows/publish.yml`**: Added fetch-depth, timeout, concurrency group, NuGet cache, `--no-restore` on test, `--skip-duplicate` on push
- **`.github/dependabot.yml`**: Removed invalid `registries: "*"`, renamed groups (`actions`, `nuget-packages`), added reviewers to github-actions section

## Test plan
- [ ] Verify `pr-check.yml` triggers on pull requests and runs build + test
- [ ] Verify `publish.yml` concurrency prevents parallel deploys
- [ ] Verify NuGet cache hits on subsequent runs
- [ ] Verify `--skip-duplicate` prevents push failures on re-runs
- [ ] Verify dependabot creates grouped PRs with correct reviewers