### PR TITLE
feat: Add Apple Pay and Google Pay digital wallet support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,13 @@ Paywire.NET/
 │   ├── PaywireClientOptions.cs      # Configuration + PaywireEndpoint enum
 │   ├── PaywireTransactionType.cs    # Transaction type constants (19 types)
 │   ├── Factories/
-│   │   └── PaywireRequestFactory.cs # Factory methods (593 lines, 25+ methods)
+│   │   └── PaywireRequestFactory.cs # Factory methods (593 lines, 29+ methods)
 │   └── Models/
 │       ├── Base/                    # Base classes and shared models
 │       │   ├── BasePaywireRequest.cs
 │       │   ├── BasePaywireResponse.cs
 │       │   ├── Customer.cs          # Customer/payment data model
+│       │   ├── DigitalWallet.cs     # Digital wallet (Apple/Google Pay) model
 │       │   ├── PaywireResult.cs     # Result enum
 │       │   └── TransactionHeader.cs # Auth and transaction metadata
 │       ├── BatchInquiry/
@@ -113,7 +114,7 @@ Paywire.NET/
 
 1. **PaywireClient** (`Paywire.NET/PaywireClient.cs`): Main client class implementing `IPaywireClient`. Uses RestSharp for HTTP operations with generic `SendRequest<T>(request, CancellationToken)` method for type-safe requests. Includes automatic transaction type inference, XXE-safe XML deserialization (`DtdProcessing.Prohibit`, `XmlResolver = null`), a static `ConcurrentDictionary<Type, XmlSerializer>` cache to prevent memory leaks, and implements `IDisposable` to dispose the `RestClient`.
 
-2. **PaywireRequestFactory** (`Paywire.NET/Factories/PaywireRequestFactory.cs`): Static factory class with 25+ methods providing fluent interfaces to create all request types.
+2. **PaywireRequestFactory** (`Paywire.NET/Factories/PaywireRequestFactory.cs`): Static factory class with 29+ methods providing fluent interfaces to create all request types.
 
 3. **Models** (`Paywire.NET/Models/`): Organized by operation type, each folder containing:
    - Request model (e.g., `SaleRequest`)
@@ -299,6 +300,7 @@ The SDK supports all major Paywire transaction types:
 | **CLOSEBATCH** | Close current batch | ✅ Implemented |
 | **BINVALIDATION** | Validate BIN information | ✅ Implemented |
 | **RECEIPT** | Get transaction receipt | ✅ Implemented |
+| **Digital Wallet** | Apple Pay / Google Pay via SALE or PREAUTH | ✅ Supported via SALE/PREAUTH |
 | **CREATECUSTOMER** | Create customer profile | ❌ Not implemented |
 | **GETCUSTOMERTOKENS** | Get customer's stored tokens | ❌ Not implemented |
 | **GETPERIODICPLAN** | Get recurring plan details | ❌ Not implemented |

--- a/Paywire.NET.Tests/UnitTests/PaywireRequestFactoryTests.cs
+++ b/Paywire.NET.Tests/UnitTests/PaywireRequestFactoryTests.cs
@@ -299,4 +299,68 @@ public class PaywireRequestFactoryTests
         var request = PaywireRequestFactory.StoreToken(header, customer);
         Assert.That(request.CUSTOMER.CARDNUMBER, Is.EqualTo(4111111111111111));
     }
+
+    [Test]
+    public void DigitalWalletSale_SetsWalletFields()
+    {
+        var request = PaywireRequestFactory.DigitalWalletSale(25.00, "A", "PAYLOAD123", firstName: "John", state: "TX");
+        Assert.That(request.DIGITAL_WALLET, Is.Not.Null);
+        Assert.That(request.DIGITAL_WALLET!.DWTYPE, Is.EqualTo("A"));
+        Assert.That(request.DIGITAL_WALLET.DWPAYLOAD, Is.EqualTo("PAYLOAD123"));
+        Assert.That(request.CUSTOMER.PWMEDIA, Is.EqualTo("CC"));
+        Assert.That(request.TRANSACTION_HEADER.PWSALEAMOUNT, Is.EqualTo(25.00));
+        Assert.That(request.CUSTOMER.FIRSTNAME, Is.EqualTo("John"));
+        Assert.That(request.CUSTOMER.STATE, Is.EqualTo("TX"));
+    }
+
+    [Test]
+    public void DigitalWalletSale_DoesNotSetCardFields()
+    {
+        var request = PaywireRequestFactory.DigitalWalletSale(10.00, "G", "PAY_DATA");
+        Assert.That(request.CUSTOMER.CARDNUMBER, Is.Null);
+        Assert.That(request.CUSTOMER.EXP_MM, Is.Null);
+        Assert.That(request.CUSTOMER.EXP_YY, Is.Null);
+        Assert.That(request.CUSTOMER.CVV2, Is.Null);
+    }
+
+    [Test]
+    public void DigitalWalletPreAuth_SetsWalletFields()
+    {
+        var request = PaywireRequestFactory.DigitalWalletPreAuth(50.00, "G", "GPAY_PAYLOAD", firstName: "Jane", state: "CA");
+        Assert.That(request.DIGITAL_WALLET, Is.Not.Null);
+        Assert.That(request.DIGITAL_WALLET!.DWTYPE, Is.EqualTo("G"));
+        Assert.That(request.DIGITAL_WALLET.DWPAYLOAD, Is.EqualTo("GPAY_PAYLOAD"));
+        Assert.That(request.CUSTOMER.PWMEDIA, Is.EqualTo("CC"));
+        Assert.That(request.TRANSACTION_HEADER.PWSALEAMOUNT, Is.EqualTo(50.00));
+    }
+
+    [Test]
+    public void Sale_WithDigitalWallet_SetsAllThreeGroups()
+    {
+        var header = new TransactionHeader { PWSALEAMOUNT = 99.00 };
+        var customer = new Customer { PWMEDIA = "CC", STATE = "NY" };
+        var wallet = new DigitalWallet { DWTYPE = "A", DWPAYLOAD = "APPLE_DATA" };
+        var request = PaywireRequestFactory.Sale(header, customer, wallet);
+        Assert.That(request.TRANSACTION_HEADER.PWSALEAMOUNT, Is.EqualTo(99.00));
+        Assert.That(request.CUSTOMER.PWMEDIA, Is.EqualTo("CC"));
+        Assert.That(request.CUSTOMER.STATE, Is.EqualTo("NY"));
+        Assert.That(request.DIGITAL_WALLET, Is.Not.Null);
+        Assert.That(request.DIGITAL_WALLET!.DWTYPE, Is.EqualTo("A"));
+        Assert.That(request.DIGITAL_WALLET.DWPAYLOAD, Is.EqualTo("APPLE_DATA"));
+    }
+
+    [Test]
+    public void PreAuth_WithDigitalWallet_SetsAllThreeGroups()
+    {
+        var header = new TransactionHeader { PWSALEAMOUNT = 200.00 };
+        var customer = new Customer { PWMEDIA = "CC", STATE = "FL" };
+        var wallet = new DigitalWallet { DWTYPE = "G", DWPAYLOAD = "GOOGLE_DATA" };
+        var request = PaywireRequestFactory.PreAuth(header, customer, wallet);
+        Assert.That(request.TRANSACTION_HEADER.PWSALEAMOUNT, Is.EqualTo(200.00));
+        Assert.That(request.CUSTOMER.PWMEDIA, Is.EqualTo("CC"));
+        Assert.That(request.CUSTOMER.STATE, Is.EqualTo("FL"));
+        Assert.That(request.DIGITAL_WALLET, Is.Not.Null);
+        Assert.That(request.DIGITAL_WALLET!.DWTYPE, Is.EqualTo("G"));
+        Assert.That(request.DIGITAL_WALLET.DWPAYLOAD, Is.EqualTo("GOOGLE_DATA"));
+    }
 }

--- a/Paywire.NET.Tests/UnitTests/XmlSerializationTests.cs
+++ b/Paywire.NET.Tests/UnitTests/XmlSerializationTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Xml.Serialization;
 using NUnit.Framework;
 using Paywire.NET.Models.Base;
+using Paywire.NET.Models.PreAuth;
 using Paywire.NET.Models.Sale;
 
 namespace Paywire.NET.Tests.UnitTests;
@@ -174,5 +175,60 @@ public class XmlSerializationTests
         Assert.That(deserialized.CUSTOMER.CARDNUMBER, Is.EqualTo(4111111111111111));
         Assert.That(deserialized.CUSTOMER.FIRSTNAME, Is.EqualTo("Jane"));
         Assert.That(deserialized.CUSTOMER.STATE, Is.EqualTo("TX"));
+    }
+
+    [Test]
+    public void SaleRequest_WithDigitalWallet_SerializesCorrectly()
+    {
+        var request = new SaleRequest
+        {
+            TRANSACTION_HEADER = new TransactionHeader { PWCLIENTID = "C1" },
+            CUSTOMER = new Customer { PWMEDIA = "CC" },
+            DIGITAL_WALLET = new DigitalWallet { DWTYPE = "A", DWPAYLOAD = "TEST_PAYLOAD" }
+        };
+
+        var xml = Serialize(request);
+
+        Assert.That(xml, Does.Contain("<DIGITALWALLET>"));
+        Assert.That(xml, Does.Contain("<DWTYPE>A</DWTYPE>"));
+        Assert.That(xml, Does.Contain("<DWPAYLOAD>TEST_PAYLOAD</DWPAYLOAD>"));
+        // DIGITALWALLET should be a sibling of TRANSACTIONHEADER and CUSTOMER
+        Assert.That(xml, Does.Contain("<TRANSACTIONHEADER>"));
+        Assert.That(xml, Does.Contain("<CUSTOMER>"));
+    }
+
+    [Test]
+    public void SaleRequest_WithoutDigitalWallet_OmitsElement()
+    {
+        var request = new SaleRequest
+        {
+            TRANSACTION_HEADER = new TransactionHeader { PWCLIENTID = "C1" },
+            CUSTOMER = new Customer { PWMEDIA = "CC" }
+        };
+
+        var xml = Serialize(request);
+
+        Assert.That(xml, Does.Not.Contain("<DIGITALWALLET>"));
+    }
+
+    [Test]
+    public void DigitalWallet_DecryptedPath_SerializesAllFields()
+    {
+        var wallet = new DigitalWallet
+        {
+            DWTYPE = "G",
+            ISTDES = "TRUE",
+            CAVV = "CAVV_DATA",
+            ECI = "05",
+            UCAF = "UCAF_IND"
+        };
+
+        var xml = Serialize(wallet);
+
+        Assert.That(xml, Does.Contain("<DWTYPE>G</DWTYPE>"));
+        Assert.That(xml, Does.Contain("<ISTDES>TRUE</ISTDES>"));
+        Assert.That(xml, Does.Contain("<CAVV>CAVV_DATA</CAVV>"));
+        Assert.That(xml, Does.Contain("<ECI>05</ECI>"));
+        Assert.That(xml, Does.Contain("<UCAF>UCAF_IND</UCAF>"));
     }
 }

--- a/Paywire.NET/Factories/PaywireRequestFactory.cs
+++ b/Paywire.NET/Factories/PaywireRequestFactory.cs
@@ -590,5 +590,93 @@ namespace Paywire.NET.Factories
             return new CaptureRequest { TRANSACTION_HEADER = new TransactionHeader { PWSALEAMOUNT = saleAmount, PWINVOICENUMBER = invoiceNumber, PWUNIQUEID = uniqueId } };
         }
 
+        /// <summary>
+        /// Process an Apple Pay or Google Pay sale with an encrypted wallet payload.
+        /// </summary>
+        /// <param name="saleAmount">Transaction amount</param>
+        /// <param name="walletType">"A" for Apple Pay, "G" for Google Pay</param>
+        /// <param name="walletPayload">Base64-encoded encrypted payload from the digital wallet</param>
+        /// <param name="firstName">Account holder's first name</param>
+        /// <param name="lastName">Account holder's last name</param>
+        /// <param name="state">Account holder's state (required for convenience fees)</param>
+        /// <param name="email">Account holder's email address</param>
+        public static SaleRequest DigitalWalletSale(double saleAmount, string walletType, string walletPayload,
+            string firstName = "", string lastName = "", string state = "", string email = "")
+        {
+            return new SaleRequest
+            {
+                TRANSACTION_HEADER = new TransactionHeader { PWSALEAMOUNT = saleAmount },
+                CUSTOMER = new Customer
+                {
+                    PWMEDIA = "CC",
+                    FIRSTNAME = firstName,
+                    LASTNAME = lastName,
+                    STATE = state,
+                    EMAIL = email
+                },
+                DIGITAL_WALLET = new DigitalWallet
+                {
+                    DWTYPE = walletType,
+                    DWPAYLOAD = walletPayload
+                }
+            };
+        }
+
+        /// <summary>
+        /// Pre-authorize an Apple Pay or Google Pay transaction with an encrypted wallet payload.
+        /// </summary>
+        /// <param name="saleAmount">Transaction amount</param>
+        /// <param name="walletType">"A" for Apple Pay, "G" for Google Pay</param>
+        /// <param name="walletPayload">Base64-encoded encrypted payload from the digital wallet</param>
+        /// <param name="firstName">Account holder's first name</param>
+        /// <param name="lastName">Account holder's last name</param>
+        /// <param name="state">Account holder's state (required for convenience fees)</param>
+        public static PreAuthRequest DigitalWalletPreAuth(double saleAmount, string walletType, string walletPayload,
+            string firstName = "", string lastName = "", string state = "")
+        {
+            return new PreAuthRequest
+            {
+                TRANSACTION_HEADER = new TransactionHeader { PWSALEAMOUNT = saleAmount },
+                CUSTOMER = new Customer
+                {
+                    PWMEDIA = "CC",
+                    FIRSTNAME = firstName,
+                    LASTNAME = lastName,
+                    STATE = state
+                },
+                DIGITAL_WALLET = new DigitalWallet
+                {
+                    DWTYPE = walletType,
+                    DWPAYLOAD = walletPayload
+                }
+            };
+        }
+
+        /// <summary>
+        /// Charge a card or bank account with digital wallet data (full-control overload).
+        /// </summary>
+        public static SaleRequest Sale(TransactionHeader header, Customer customer, DigitalWallet digitalWallet)
+        {
+            return new SaleRequest
+            {
+                TRANSACTION_HEADER = header,
+                CUSTOMER = customer,
+                DIGITAL_WALLET = digitalWallet
+            };
+        }
+
+        /// <summary>
+        /// Pre-authorize a card with digital wallet data (full-control overload).
+        /// </summary>
+        public static PreAuthRequest PreAuth(TransactionHeader header, Customer customer, DigitalWallet digitalWallet)
+        {
+            return new PreAuthRequest
+            {
+                TRANSACTION_HEADER = header,
+                CUSTOMER = customer,
+                DIGITAL_WALLET = digitalWallet
+            };
+        }
+
     }
 }

--- a/Paywire.NET/Models/Base/DigitalWallet.cs
+++ b/Paywire.NET/Models/Base/DigitalWallet.cs
@@ -1,0 +1,38 @@
+namespace Paywire.NET.Models.Base;
+
+/// <summary>
+/// Digital wallet data for Apple Pay and Google Pay transactions.
+/// Use EITHER the encrypted path (DWPAYLOAD) OR the decrypted path (CAVV/ECI fields), not both.
+/// </summary>
+public class DigitalWallet
+{
+    /// <summary>
+    /// Wallet type. "A" for Apple Pay, "G" for Google Pay.
+    /// </summary>
+    public string? DWTYPE { get; set; }
+
+    /// <summary>
+    /// Base64-encoded encrypted payload from the digital wallet (encrypted path).
+    /// </summary>
+    public string? DWPAYLOAD { get; set; }
+
+    /// <summary>
+    /// "TRUE" or "FALSE" — indicates if the card data has been decrypted (decrypted path).
+    /// </summary>
+    public string? ISTDES { get; set; }
+
+    /// <summary>
+    /// CAVV data from the authenticator (decrypted path).
+    /// </summary>
+    public string? CAVV { get; set; }
+
+    /// <summary>
+    /// ECI value from the authenticator (decrypted path).
+    /// </summary>
+    public string? ECI { get; set; }
+
+    /// <summary>
+    /// UCAF indicator — MasterCard only (decrypted path).
+    /// </summary>
+    public string? UCAF { get; set; }
+}

--- a/Paywire.NET/Models/PreAuth/PreAuthRequest.cs
+++ b/Paywire.NET/Models/PreAuth/PreAuthRequest.cs
@@ -8,5 +8,8 @@ namespace Paywire.NET.Models.PreAuth
     {
         [XmlElement("CUSTOMER")]
         public Customer CUSTOMER { get; set; } = new();
+
+        [XmlElement("DIGITALWALLET")]
+        public DigitalWallet? DIGITAL_WALLET { get; set; }
     }
 }

--- a/Paywire.NET/Models/Sale/SaleRequest.cs
+++ b/Paywire.NET/Models/Sale/SaleRequest.cs
@@ -8,4 +8,7 @@ public class SaleRequest : BasePaywireRequest
 {
     [XmlElement("CUSTOMER")]
     public Customer CUSTOMER { get; set; } = new();
+
+    [XmlElement("DIGITALWALLET")]
+    public DigitalWallet? DIGITAL_WALLET { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -10,3 +10,63 @@ This library uses `XmlSerializer` for XML serialization/deserialization. `Paywir
 
 ### Security
 XML deserialization uses a hardened `XmlReader` with `DtdProcessing.Prohibit` and `XmlResolver = null` to prevent XXE (XML External Entity) attacks.
+
+## Digital Wallet Support (Apple Pay / Google Pay)
+
+The SDK supports Apple Pay and Google Pay transactions via the `DIGITALWALLET` XML group. Digital wallet transactions reuse existing `SALE` and `PREAUTH` transaction types.
+
+### Quick Start (Encrypted Payload)
+
+```csharp
+// Apple Pay sale
+var applePaySale = PaywireRequestFactory.DigitalWalletSale(
+    saleAmount: 25.00,
+    walletType: "A",           // "A" = Apple Pay
+    walletPayload: "BASE64_ENCRYPTED_PAYLOAD_FROM_APPLE",
+    firstName: "John",
+    lastName: "Doe",
+    state: "TX",
+    email: "john@example.com"
+);
+var response = await client.SendRequest<SaleResponse>(applePaySale);
+
+// Google Pay pre-authorization
+var googlePayPreAuth = PaywireRequestFactory.DigitalWalletPreAuth(
+    saleAmount: 100.00,
+    walletType: "G",           // "G" = Google Pay
+    walletPayload: "BASE64_ENCRYPTED_PAYLOAD_FROM_GOOGLE",
+    firstName: "Jane",
+    lastName: "Smith",
+    state: "CA"
+);
+var preAuthResponse = await client.SendRequest<PreAuthResponse>(googlePayPreAuth);
+```
+
+### Full-Control Overload
+
+```csharp
+var request = PaywireRequestFactory.Sale(
+    header: new TransactionHeader { PWSALEAMOUNT = 50.00 },
+    customer: new Customer { PWMEDIA = "CC", STATE = "NY" },
+    digitalWallet: new DigitalWallet
+    {
+        DWTYPE = "A",
+        DWPAYLOAD = "BASE64_ENCRYPTED_PAYLOAD"
+    }
+);
+```
+
+### Decrypted Path
+
+If you decrypt the wallet payload yourself, use the decrypted fields instead:
+
+```csharp
+var wallet = new DigitalWallet
+{
+    DWTYPE = "G",
+    ISTDES = "TRUE",
+    CAVV = "CAVV_DATA_HERE",
+    ECI = "05",
+    UCAF = "UCAF_INDICATOR"   // MasterCard only
+};
+```


### PR DESCRIPTION
## Summary

- Add `DigitalWallet` model with support for both encrypted (DWPAYLOAD) and decrypted (CAVV/ECI) wallet paths
- Add `DIGITAL_WALLET` property to `SaleRequest` and `PreAuthRequest` — null by default, omitted from XML when unset (no regression)
- Add 4 factory methods: `DigitalWalletSale`, `DigitalWalletPreAuth`, and full-control `Sale`/`PreAuth` overloads with wallet parameter
- Add 8 unit tests (5 factory + 3 XML serialization) — all 65 unit tests pass
- Update CLAUDE.md and README.md with documentation and usage examples

## Test plan

- [x] `dotnet build --configuration Release --no-incremental` — 0 warnings, 0 errors
- [x] `dotnet test --filter "FullyQualifiedName~UnitTests"` — 65 passed, 0 failed
- [x] Existing tests unaffected (null DIGITAL_WALLET omits element entirely)
- [ ] Verify PR checks pass on CI